### PR TITLE
Phase 1: Audit & Cleanup

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,26 @@
+name: Link Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build MkDocs site
+        run: |
+          pip install mkdocs-material
+          mkdocs build --strict
+
+      - name: Check links with lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --base site/
+            --include-fragments
+            --no-progress
+            'site/**/*.html'
+          fail: true

--- a/docs/source/guide-to-java-level-1.md
+++ b/docs/source/guide-to-java-level-1.md
@@ -650,6 +650,6 @@ for (int item : arr) {
 Once you've completed this guide and can check off all the "Check Your Understanding" items:
 
 * **FTC Students:** Continue to **Level 2: Java for FTC**  
-* **FRC Students:** Continue to **Level 3: Java Refresher for FRC**
+* **FRC Students:** Continue to **Level 4: FRC Basics**
 
 Remember: The goal isn't to memorize everything — it's to understand enough to start writing robot code, then learn more as you go\!

--- a/docs/source/guide-to-java-level-2.md
+++ b/docs/source/guide-to-java-level-2.md
@@ -531,7 +531,7 @@ Once you're comfortable with these basics:
 2. **Learn about sensors** — Color sensors, distance sensors, touch sensors  
 3. **Learn about roadrunner/pedropathing** — Advanced autonomous path following
 
-And when you move to FRC in high school, you'll be ready for **Level 3: Java Refresher for FRC**, which shows you how these concepts translate to the Command-Based framework\!
+And when you move to FRC in high school, you'll be ready for **Level 4: FRC Basics**, which shows you how these concepts translate to the Command-Based framework\!
 
 ---
 

--- a/docs/source/guide-to-java-level-3.md
+++ b/docs/source/guide-to-java-level-3.md
@@ -20,13 +20,13 @@ FTC students who have the basics down and want to write cleaner, more reliable c
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
-│              LEVEL 2.5: Advanced FTC Patterns               │
+│              LEVEL 3: Advanced FTC Patterns                 │
 │                      (You are here)                         │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
               Ready for competition-quality code!
-                    (or Level 3 for FRC transition)
+                    (or Level 4 for FRC transition)
 ```
 
 ---
@@ -956,4 +956,4 @@ You now have the tools to write competition-quality FTC code:
 
 When you're ready for FRC, these patterns will translate directly — FRC's Command-Based framework is essentially a more sophisticated version of what you just learned\!
 
-Continue to **Level 3: Java Refresher for FRC** when you join a high school team.
+Continue to **Level 4: FRC Basics** when you join a high school team.

--- a/docs/source/guide-to-java-level-4.md
+++ b/docs/source/guide-to-java-level-4.md
@@ -3,7 +3,7 @@
 ## **Who Is This For?**
 
 High school FRC students transitioning from FTC, or students with Java basics who are new to FRC. This guide bridges what you already know into FRC's Command-Based framework.  
-**Prerequisites:** Java basics (Level 1\) and ideally FTC experience (Level 2/2.5)  
+**Prerequisites:** Java basics (Level 1\) and ideally FTC experience (Level 2/3)  
 **Time to Complete:** 1-2 weeks before build season
 
 ## **Your Learning Path**
@@ -12,19 +12,19 @@ High school FRC students transitioning from FTC, or students with Java basics wh
 ┌─────────────────────────────────────────────────────────────┐
 │            LEVEL 1: Java Foundations                        │
 │            LEVEL 2: Java for FTC (if applicable)            │
-│            LEVEL 2.5: Advanced FTC Patterns (if applicable) │
+│            LEVEL 3: Advanced FTC Patterns (if applicable)   │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                LEVEL 3: Java for FRC                        │
+│                LEVEL 4: FRC Basics                          │
 │                    (You are here)                           │
 │         Transition from FTC → FRC Command-Based             │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                    LEVEL 4: Advanced FRC                    │
+│                    LEVEL 5: Advanced FRC                    │
 │     Commands Deep Dive • Triggers • State Machines          │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -449,7 +449,7 @@ public static final int MOTOR_ID = 5;
 
 ## **Your FTC State Machines Still Work\!**
 
-If you learned state machines in Level 2.5, great news — they work the same way in FRC:
+If you learned state machines in Level 3, great news — they work the same way in FRC:
 
 ```java
 public class Intake extends SubsystemBase {
@@ -669,7 +669,7 @@ Once you're comfortable with:
 * Button bindings in RobotContainer  
 * Constants organization
 
-Continue to **Level 4: Advanced FRC Patterns**:
+Continue to **Level 5: Advanced FRC Patterns**:
 
 * Command compositions (sequence, parallel, race)  
 * Complex triggers and bindings  

--- a/docs/source/guide-to-java-level-5.md
+++ b/docs/source/guide-to-java-level-5.md
@@ -4,7 +4,7 @@
 
 FRC students who understand the basics of Command-Based and want to level up. This guide covers command compositions, advanced triggers, state machines, and patterns used by competitive teams.
 
-**Prerequisites:** Level 3: Java for FRC (comfortable with subsystems, basic commands, button bindings)
+**Prerequisites:** Level 4: FRC Basics (comfortable with subsystems, basic commands, button bindings)
 
 **Time to Complete:** Ongoing reference throughout the season
 
@@ -12,13 +12,13 @@ FRC students who understand the basics of Command-Based and want to level up. Th
 
 ```java
 ┌─────────────────────────────────────────────────────────────┐
-│                LEVEL 3: Java for FRC                        │
+│                LEVEL 4: FRC Basics                          │
 │              (Subsystems, Commands, Bindings)               │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
-│              LEVEL 4: Advanced FRC Patterns                 │
+│              LEVEL 5: Advanced FRC Patterns                 │
 │                      (You are here)                         │
 │                                                             │
 │  Part 1: Command Compositions                               │

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,12 +30,7 @@ theme:
         name: Switch to light mode
 
 nav:
-  - Home: introduction.md
-  # - Quick Links: quick-links-hub.md
-  # - Getting Started:
-  #  - Introduction: Introduction.md
-  #  - Software Setup: Software-Installation-Setup.md
-  #  - GitHub Workflow: GitHub-Workflow.md
+  - Home: index.md
   - Learn Java:
     - Level 1: guide-to-java-level-1.md
     - Level 2: guide-to-java-level-2.md
@@ -43,38 +38,6 @@ nav:
     - Level 4: guide-to-java-level-4.md
     - Level 5: guide-to-java-level-5.md
     - Level 6: guide-to-java-level-6.md
-  #- Controls:
-  #  - Introduction: controls/introduction.md
-  #  - Guide to Controls: controls/3603-guide-to-controls.md
-  #  - FAQ for Beginners: controls/FAQ-for-beginners.md
-  #  - CTRE: controls/ctre.md
-  #  - WPILib: controls/wpilib.md
-  #  - PathPlanner: controls/path-planner.md
-  #  - Autonomous PathPlanner: controls/auton-pathplanner.md
-  #  - Motion Profiling: controls/motion-profiling.md
-  #  - PID: controls/pid.md
-  #  - Limelight: controls/limelight.md
-  #  - PhotonVision: controls/photonvision.md
-  #  - PhotonVision on Limelight: controls/photonvision-on-a-limelight.md
-  #  - LEDs: controls/leds.md
-  #  - Limit Switches: controls/sensors-limit-switches.md
-  #  - Control an Arm: controls/control-an-arm.md
-  #  - Software Updates: controls/software-updates.md
-  #  - Style Guides: controls/style-guides.md
-  #  - Conventions: controls/conventions-style-guide.md
-  #  - Team History: controls/history-controls.md
-  #  - Programming Resources: controls/programming-resources.md
-  #  - Resources: controls/resources.md
-  #  - Where Am I: controls/whereami.md
-  #- Team:
-  #  - Team Build: team-build.md
-  #  - Team Business: team-business.md
-  #  - Controls Team: team-controls.md
-  #  - Organization: organization.md
-  #  - Community: community.md
-  #  - Calendar: calendar.md
-  #  - Events: events.md
-  #- Vendor Deps: vendordeps-list.md
 
 plugins:
   - search


### PR DESCRIPTION
## Summary

Mechanical cleanup pass before any content work begins. Brings filenames, navigation, and internal level-number cross-references into a consistent state.

## Acceptance checklist

- [x] **`mkdocs build --strict` exits 0** — verified locally, zero warnings
- [x] **Every nav entry in `mkdocs.yml` resolves to a real file** — fixed `introduction.md` → `index.md`; all six level files exist
- [x] **No commented-out nav entries remain** — removed all five commented blocks (Quick Links, Getting Started, Controls, Team, Vendor Deps)
- [x] **No file refers to itself by the wrong level number** — all "Level 2.5" and mispointed level references corrected (see details below)
- [x] **New CI workflow exists, runs on push and PR, fails on broken internal links** — `.github/workflows/link-check.yml` added

## What changed

### `mkdocs.yml`
- `Home: introduction.md` → `Home: index.md` (`introduction.md` never existed; `index.md` is the actual file)
- Deleted five commented-out nav blocks; commented config rots and misleads

### Level numbering corrections

The files were written when Level 3 was called "Level 2.5" and the FRC levels were shifted down by one. Every cross-reference now matches the canonical 1–6 scheme in `mkdocs.yml`.

| File | Was | Now |
|---|---|---|
| `level-1.md` — What's Next | "Level 3: Java Refresher for FRC" | "Level 4: FRC Basics" |
| `level-2.md` — What's Next | "Level 3: Java Refresher for FRC" | "Level 4: FRC Basics" |
| `level-3.md` — learning-path diagram | "LEVEL 2.5: Advanced FTC Patterns (You are here)" | "LEVEL 3: Advanced FTC Patterns (You are here)" |
| `level-3.md` — learning-path diagram | "(or Level 3 for FRC transition)" | "(or Level 4 for FRC transition)" |
| `level-3.md` — What's Next | "Continue to Level 3: Java Refresher for FRC" | "Continue to Level 4: FRC Basics" |
| `level-4.md` — prerequisites | "Level 2/2.5" | "Level 2/3" |
| `level-4.md` — learning-path diagram | "LEVEL 2.5 … (if applicable)" | "LEVEL 3 … (if applicable)" |
| `level-4.md` — learning-path diagram "You are here" | "LEVEL 3: Java for FRC" | "LEVEL 4: FRC Basics" |
| `level-4.md` — learning-path diagram next step | "LEVEL 4: Advanced FRC" | "LEVEL 5: Advanced FRC" |
| `level-4.md` — body | "Level 2.5" | "Level 3" |
| `level-4.md` — What's Next | "Continue to Level 4: Advanced FRC Patterns" | "Continue to Level 5: Advanced FRC Patterns" |
| `level-5.md` — prerequisites | "Level 3: Java for FRC" | "Level 4: FRC Basics" |
| `level-5.md` — learning-path diagram prereq box | "LEVEL 3: Java for FRC" | "LEVEL 4: FRC Basics" |
| `level-5.md` — learning-path diagram "You are here" | "LEVEL 4: Advanced FRC Patterns" | "LEVEL 5: Advanced FRC Patterns" |

### `.github/workflows/link-check.yml` (new)
Runs on every push and every PR. Builds the MkDocs site with `--strict`, then runs `lychee` over all generated HTML. Fails the build if any internal link is broken.

### `docs/archive/` — no action needed
`mkdocs.yml` sets `docs_dir: docs/source`, so `docs/archive/` is already excluded from the site build.

## Out of scope
Content rewriting, adding new sections, restructuring level content — all deferred to Phase 2+.

https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt)_