### PR TITLE
fix: lychee --base must be an absolute path

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,8 +19,8 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
-            --base site/
+            --base "${{ github.workspace }}/site"
             --include-fragments
             --no-progress
-            'site/**/*.html'
+            '${{ github.workspace }}/site/**/*.html'
           fail: true


### PR DESCRIPTION
## Problem

The link-check workflow was failing immediately with exit code 2:

```
error: invalid value 'site/' for '--base <BASE>':
Error with base dir `site/`: Base must either be a URL (with scheme)
or an absolute local path.
```

`lychee` rejects relative paths for `--base` at startup — it never even gets to check any links.

## Fix

Replace the relative `site/` path with `${{ github.workspace }}/site` (an absolute path) in both the `--base` flag and the file glob.

```diff
- --base site/
+ --base "${{ github.workspace }}/site"
  --include-fragments
  --no-progress
- 'site/**/*.html'
+ '${{ github.workspace }}/site/**/*.html'
```

https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt)_