### PR TITLE
Phase 8: Companion Repo Skeleton, CI Check, and Handbook Linkage

### DIFF
--- a/.github/workflows/companion-check.yml
+++ b/.github/workflows/companion-check.yml
@@ -1,0 +1,53 @@
+name: Companion Projects Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  companion-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify companion project files exist
+        run: |
+          missing=0
+          check() {
+            if [ ! -f "$1" ]; then
+              echo "MISSING: $1"
+              missing=$((missing + 1))
+            else
+              echo "OK: $1"
+            fi
+          }
+
+          check companion/level-1/MatchScorer/MatchScorer.java
+
+          check companion/level-2/IntakeSubsystem/IntakeSubsystem.java
+          check companion/level-2/IntakeSubsystem/IntakeCapstone.java
+
+          check companion/level-3/CoordinatedRobot/IntakeSubsystem.java
+          check companion/level-3/CoordinatedRobot/ArmSubsystem.java
+          check companion/level-3/CoordinatedRobot/CoordinatedTeleOp.java
+
+          check companion/level-4/CommandIntake/Constants.java
+          check companion/level-4/CommandIntake/IntakeSubsystem.java
+          check companion/level-4/CommandIntake/IntakeCommands.java
+          check companion/level-4/CommandIntake/RobotContainer.java
+
+          check companion/level-5/ElevatorAuto/ElevatorCommands.java
+          check companion/level-5/ElevatorAuto/AutonomousRoutines.java
+
+          check companion/level-6/VisionAssistedAuto/VisionSubsystem.java
+          check companion/level-6/VisionAssistedAuto/VisionPoseUpdater.java
+          check companion/level-6/VisionAssistedAuto/DriveToNearestScoringLocation.java
+          check companion/level-6/VisionAssistedAuto/AutonomousRoutines.java
+
+          if [ $missing -gt 0 ]; then
+            echo ""
+            echo "ERROR: $missing expected companion file(s) are missing."
+            exit 1
+          fi
+          echo ""
+          echo "All companion project files present."

--- a/companion/README.md
+++ b/companion/README.md
@@ -1,0 +1,29 @@
+# Programmer's Handbook — Companion Projects
+
+Every major code example from the handbook lives here as a standalone source file, organized by level. Each project is referenced from the handbook with a direct link.
+
+## Structure
+
+```
+companion/
+  level-1/MatchScorer/          Pure Java (no hardware)
+  level-2/IntakeSubsystem/      FTC SDK (LinearOpMode)
+  level-3/CoordinatedRobot/     FTC SDK (multi-subsystem)
+  level-4/CommandIntake/        FRC WPILib command-based
+  level-5/ElevatorAuto/         FRC WPILib + CTRE + Choreo
+  level-6/VisionAssistedAuto/   FRC WPILib + CTRE + Limelight
+```
+
+## Link Convention
+
+Handbook files reference companion projects with:
+
+```markdown
+> **Full project:** [`companion/level-N/ExampleName`](https://github.com/CyberCoyotes/Programmers-Handbook/tree/main/companion/level-N/ExampleName)
+```
+
+## Notes
+
+- Source files use the package structure they would have inside a real project (`frc.robot.*`, `org.firstinspires.ftc.teamcode.*`).
+- Files are not part of a full Gradle project — they are standalone reference sources. A full deployable project skeleton is a future addition.
+- CI verifies that expected files exist on every push.

--- a/companion/level-1/MatchScorer/MatchScorer.java
+++ b/companion/level-1/MatchScorer/MatchScorer.java
@@ -1,0 +1,73 @@
+// Level 1 capstone — pure Java, no hardware required.
+// See: docs/source/guide-to-java-level-1.md — Capstone: MatchScorer
+
+public class MatchScorer {
+
+    // Point values for each reef level (teleop scoring, 2025 Reefscape rules).
+    // Keep constants together — when the game changes, there is exactly one place to update.
+    private static final int L1_POINTS = 2;
+    private static final int L2_POINTS = 3;
+    private static final int L3_POINTS = 4;
+    private static final int L4_POINTS = 5;
+    private static final int CLIMB_POINTS = 12;
+
+    private String teamName;
+    private int[] coralPerLevel;  // index 0 = Level 1 reef, index 3 = Level 4 reef
+    private boolean climbed;
+
+    // Constructor — one MatchScorer per team per match
+    public MatchScorer(String teamName) {
+        this.teamName = teamName;
+        coralPerLevel = new int[4];  // all zeros by default
+    }
+
+    // Record coral scored at a reef level (valid levels: 1–4)
+    public void recordCoral(int level, int count) {
+        if (level >= 1 && level <= 4) {
+            coralPerLevel[level - 1] += count;  // convert 1-based level to 0-based array index
+        }
+    }
+
+    public void setClimbed(boolean didClimb) {
+        climbed = didClimb;
+    }
+
+    // Loop through each level, multiply coral count by that level's point value, sum them up
+    public int coralScore() {
+        int[] pointsPerLevel = {L1_POINTS, L2_POINTS, L3_POINTS, L4_POINTS};
+        int total = 0;
+        for (int i = 0; i < coralPerLevel.length; i++) {
+            total += coralPerLevel[i] * pointsPerLevel[i];
+        }
+        return total;
+    }
+
+    public int endgameScore() {
+        return climbed ? CLIMB_POINTS : 0;
+    }
+
+    public int totalScore() {
+        return coralScore() + endgameScore();
+    }
+
+    public void printReport() {
+        System.out.println("=== " + teamName + " Match Report ===");
+        System.out.println("Coral score:   " + coralScore()   + " pts");
+        System.out.println("Endgame score: " + endgameScore() + " pts");
+        System.out.println("TOTAL:         " + totalScore()   + " pts");
+    }
+
+    // Quick smoke-test — run with: javac MatchScorer.java && java MatchScorer
+    public static void main(String[] args) {
+        MatchScorer team3603 = new MatchScorer("Team 3603");
+        team3603.recordCoral(3, 2);
+        team3603.recordCoral(4, 1);
+        team3603.setClimbed(true);
+        team3603.printReport();
+        // Expected:
+        // === Team 3603 Match Report ===
+        // Coral score:   13 pts
+        // Endgame score: 12 pts
+        // TOTAL:         25 pts
+    }
+}

--- a/companion/level-2/IntakeSubsystem/IntakeCapstone.java
+++ b/companion/level-2/IntakeSubsystem/IntakeCapstone.java
@@ -1,0 +1,40 @@
+// Level 2 capstone — OpMode that uses IntakeSubsystem.
+// See: docs/source/guide-to-java-level-2.md — Capstone: IntakeSubsystem
+
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import org.firstinspires.ftc.teamcode.Subsystems.IntakeSubsystem;
+
+@TeleOp(name = "Intake Capstone")
+public class IntakeCapstone extends LinearOpMode {
+
+    private IntakeSubsystem intake;
+
+    @Override
+    public void runOpMode() {
+        intake = new IntakeSubsystem(hardwareMap);
+
+        telemetry.addData("Status", "Initialized");
+        telemetry.update();
+
+        waitForStart();
+
+        while (opModeIsActive()) {
+            // Driver input sets the desired state
+            if (gamepad1.a) {
+                intake.intake();
+            } else if (gamepad1.b) {
+                intake.hold();
+            } else if (gamepad1.x) {
+                intake.stop();
+            }
+
+            // update() applies whatever state was last set — even if no button is pressed now
+            intake.update();
+            intake.addTelemetry(telemetry);
+            telemetry.update();
+        }
+    }
+}

--- a/companion/level-2/IntakeSubsystem/IntakeSubsystem.java
+++ b/companion/level-2/IntakeSubsystem/IntakeSubsystem.java
@@ -1,0 +1,49 @@
+// Level 2 capstone — FTC SDK, LinearOpMode pattern.
+// See: docs/source/guide-to-java-level-2.md — Capstone: IntakeSubsystem
+
+package org.firstinspires.ftc.teamcode.Subsystems;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+
+public class IntakeSubsystem {
+
+    // The three modes this intake can be in.
+    // An enum keeps states explicit — no more magic numbers or stray booleans.
+    public enum IntakeState {
+        INTAKING,
+        HOLDING,   // slow reverse keeps the game piece from falling out
+        STOPPED
+    }
+
+    private final DcMotor motor;
+    private IntakeState state = IntakeState.STOPPED;
+
+    public IntakeSubsystem(HardwareMap hardwareMap) {
+        motor = hardwareMap.get(DcMotor.class, "intake");
+        motor.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+    }
+
+    // Methods describe robot intent, not hardware action
+    public void intake() { state = IntakeState.INTAKING; }
+    public void hold()   { state = IntakeState.HOLDING;  }
+    public void stop()   { state = IntakeState.STOPPED;  }
+
+    public IntakeState getState() { return state; }
+
+    // Call this once per loop to apply the current state to the hardware
+    public void update() {
+        switch (state) {
+            case INTAKING: motor.setPower(1.0);    break;
+            case HOLDING:  motor.setPower(-0.15);  break;
+            case STOPPED:
+            default:       motor.setPower(0);      break;
+        }
+    }
+
+    public void addTelemetry(Telemetry telemetry) {
+        telemetry.addData("Intake state", state);
+        telemetry.addData("Intake power", motor.getPower());
+    }
+}

--- a/companion/level-3/CoordinatedRobot/ArmSubsystem.java
+++ b/companion/level-3/CoordinatedRobot/ArmSubsystem.java
@@ -1,0 +1,39 @@
+// Level 3 capstone — multi-subsystem coordination, FTC SDK.
+// See: docs/source/guide-to-java-level-3.md — Capstone: Intake + Arm Coordination
+
+package org.firstinspires.ftc.teamcode.subsystems;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+public class ArmSubsystem {
+
+    public enum Position { STOWED, INTAKE, SCORE }
+
+    private final DcMotor motor;
+    private Position target = Position.STOWED;
+    private boolean locked = false;  // true when movement is blocked by coordination rules
+
+    public ArmSubsystem(HardwareMap hardwareMap) {
+        motor = hardwareMap.get(DcMotor.class, "arm");
+    }
+
+    // Requests a position change — silently ignored when locked
+    public void goTo(Position position) {
+        if (!locked) target = position;
+    }
+
+    public void setLocked(boolean locked) { this.locked = locked; }
+    public Position getTarget()           { return target; }
+    public boolean isLocked()             { return locked; }
+
+    public void update() {
+        // Simplified: a real robot would use encoder-based position control here
+        switch (target) {
+            case SCORE:  motor.setPower(-0.4); break;
+            case INTAKE: motor.setPower(0.4);  break;
+            case STOWED:
+            default:     motor.setPower(0);    break;
+        }
+    }
+}

--- a/companion/level-3/CoordinatedRobot/CoordinatedTeleOp.java
+++ b/companion/level-3/CoordinatedRobot/CoordinatedTeleOp.java
@@ -1,0 +1,59 @@
+// Level 3 capstone — multi-subsystem coordination, FTC SDK.
+// See: docs/source/guide-to-java-level-3.md — Capstone: Intake + Arm Coordination
+
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import org.firstinspires.ftc.teamcode.subsystems.ArmSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.IntakeSubsystem;
+
+@TeleOp(name = "Coordinated TeleOp")
+public class CoordinatedTeleOp extends LinearOpMode {
+
+    private IntakeSubsystem intake;
+    private ArmSubsystem arm;
+
+    @Override
+    public void runOpMode() {
+        intake = new IntakeSubsystem(hardwareMap);
+        arm    = new ArmSubsystem(hardwareMap);
+
+        telemetry.addData("Status", "Ready");
+        telemetry.update();
+        waitForStart();
+
+        while (opModeIsActive()) {
+            handleInput();
+            coordinateSubsystems();
+
+            intake.update();
+            arm.update();
+
+            telemetry.addData("Intake",     intake.getState());
+            telemetry.addData("Arm target", arm.getTarget());
+            telemetry.addData("Arm locked", arm.isLocked());
+            telemetry.update();
+        }
+    }
+
+    private void handleInput() {
+        if (gamepad1.a)            intake.startIntaking();
+        if (gamepad1.b)            intake.hold();
+        if (gamepad1.x)            intake.stop();
+
+        if (gamepad1.right_bumper) arm.goTo(ArmSubsystem.Position.SCORE);
+        if (gamepad1.left_bumper)  arm.goTo(ArmSubsystem.Position.INTAKE);
+        if (gamepad1.y)            arm.goTo(ArmSubsystem.Position.STOWED);
+    }
+
+    private void coordinateSubsystems() {
+        // Rule 1: arm cannot score while intake is still running (piece not yet secured)
+        arm.setLocked(intake.getState() == IntakeSubsystem.State.INTAKING);
+
+        // Rule 2: once the driver signals the piece is held, automatically stage for scoring
+        if (intake.isHolding()) {
+            arm.goTo(ArmSubsystem.Position.SCORE);
+        }
+    }
+}

--- a/companion/level-3/CoordinatedRobot/IntakeSubsystem.java
+++ b/companion/level-3/CoordinatedRobot/IntakeSubsystem.java
@@ -1,0 +1,36 @@
+// Level 3 capstone — multi-subsystem coordination, FTC SDK.
+// See: docs/source/guide-to-java-level-3.md — Capstone: Intake + Arm Coordination
+
+package org.firstinspires.ftc.teamcode.subsystems;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+public class IntakeSubsystem {
+
+    public enum State { IDLE, INTAKING, HOLDING }
+
+    private final DcMotor motor;
+    private State state = State.IDLE;
+
+    public IntakeSubsystem(HardwareMap hardwareMap) {
+        motor = hardwareMap.get(DcMotor.class, "intake");
+        motor.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+    }
+
+    public void startIntaking() { state = State.INTAKING; }
+    public void hold()          { state = State.HOLDING;  }
+    public void stop()          { state = State.IDLE;     }
+
+    public State getState()    { return state; }
+    public boolean isHolding() { return state == State.HOLDING; }
+
+    public void update() {
+        switch (state) {
+            case INTAKING: motor.setPower(1.0);   break;
+            case HOLDING:  motor.setPower(0.15);  break;
+            case IDLE:
+            default:       motor.setPower(0);     break;
+        }
+    }
+}

--- a/companion/level-4/CommandIntake/Constants.java
+++ b/companion/level-4/CommandIntake/Constants.java
@@ -1,0 +1,16 @@
+// Level 4 capstone — FRC command-based with CTRE hardware.
+// See: docs/source/guide-to-java-level-4.md — Capstone: Command-Based Intake (CTRE Hardware)
+
+package frc.robot;
+
+public final class Constants {
+
+    public static final class IntakeConstants {
+        public static final int MOTOR_ID    = 1;    // verify CAN ID in Phoenix Tuner X
+        public static final double RUN_SPEED = 0.8;
+    }
+
+    public static final class OperatorConstants {
+        public static final int CONTROLLER_PORT = 0;
+    }
+}

--- a/companion/level-4/CommandIntake/IntakeCommands.java
+++ b/companion/level-4/CommandIntake/IntakeCommands.java
@@ -1,0 +1,27 @@
+// Level 4 capstone — FRC command-based with CTRE hardware.
+// See: docs/source/guide-to-java-level-4.md — Capstone: Command-Based Intake (CTRE Hardware)
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystems.IntakeSubsystem;
+
+public final class IntakeCommands {
+
+    private IntakeCommands() {}
+
+    // Runs the intake while active; third arg registers the requirement
+    public static Command run(IntakeSubsystem intake) {
+        return Commands.startEnd(
+            intake::run,
+            intake::stop,
+            intake
+        );
+    }
+
+    // Default command — motor stopped, requirement held so nothing else sneaks in
+    public static Command idle(IntakeSubsystem intake) {
+        return Commands.run(intake::stop, intake);
+    }
+}

--- a/companion/level-4/CommandIntake/IntakeSubsystem.java
+++ b/companion/level-4/CommandIntake/IntakeSubsystem.java
@@ -1,0 +1,33 @@
+// Level 4 capstone — FRC command-based with CTRE hardware.
+// See: docs/source/guide-to-java-level-4.md — Capstone: Command-Based Intake (CTRE Hardware)
+
+package frc.robot.subsystems;
+
+import com.ctre.phoenix6.controls.DutyCycleOut;
+import com.ctre.phoenix6.hardware.TalonFX;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+import static frc.robot.Constants.IntakeConstants.*;
+
+public class IntakeSubsystem extends SubsystemBase {
+
+    private final TalonFX motor = new TalonFX(MOTOR_ID);
+
+    // Reuse one control request object — avoids allocating garbage every loop
+    private final DutyCycleOut dutyCycle = new DutyCycleOut(0);
+
+    public void run() {
+        motor.setControl(dutyCycle.withOutput(RUN_SPEED));
+    }
+
+    public void stop() {
+        motor.setControl(dutyCycle.withOutput(0));
+    }
+
+    @Override
+    public void periodic() {
+        SmartDashboard.putNumber("Intake/CurrentAmps",
+            motor.getSupplyCurrent().getValueAsDouble());
+    }
+}

--- a/companion/level-4/CommandIntake/RobotContainer.java
+++ b/companion/level-4/CommandIntake/RobotContainer.java
@@ -1,0 +1,28 @@
+// Level 4 capstone — FRC command-based with CTRE hardware.
+// See: docs/source/guide-to-java-level-4.md — Capstone: Command-Based Intake (CTRE Hardware)
+
+package frc.robot;
+
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import frc.robot.commands.IntakeCommands;
+import frc.robot.subsystems.IntakeSubsystem;
+
+public class RobotContainer {
+
+    // One instance — passed to everything that needs it
+    private final IntakeSubsystem intake = new IntakeSubsystem();
+
+    private final CommandXboxController operator =
+        new CommandXboxController(Constants.OperatorConstants.CONTROLLER_PORT);
+
+    public RobotContainer() {
+        // Default command: motor stopped whenever nothing else is scheduled
+        intake.setDefaultCommand(IntakeCommands.idle(intake));
+        configureBindings();
+    }
+
+    private void configureBindings() {
+        // Right trigger held → run; release → command ends → stop() called automatically
+        operator.rightTrigger().whileTrue(IntakeCommands.run(intake));
+    }
+}

--- a/companion/level-5/ElevatorAuto/AutonomousRoutines.java
+++ b/companion/level-5/ElevatorAuto/AutonomousRoutines.java
@@ -1,0 +1,59 @@
+// Level 5 capstone — elevator + intake autonomous routine.
+// See: docs/source/guide-to-java-level-5.md — Capstone: Elevator + Intake Autonomous Routine
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystems.DrivetrainSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem.ElevatorPosition;
+import frc.robot.subsystems.IntakeSubsystem;
+
+public final class AutonomousRoutines {
+
+    private AutonomousRoutines() {}
+
+    /**
+     * Score preload at L4, drive to first game piece while lowering to intake height,
+     * grab the piece, then drive back and score at L2.
+     *
+     * Aborts cleanly if the elevator reports a fault.
+     */
+    public static Command scoreTwoPiece(
+        DrivetrainSubsystem drivetrain,
+        ElevatorSubsystem   elevator,
+        IntakeSubsystem     intake
+    ) {
+        return Commands.sequence(
+            // 1. Score preload at L4
+            ElevatorCommands.goTo(elevator, ElevatorPosition.L4),
+            IntakeCommands.eject(intake).withTimeout(0.5),
+
+            // 2. Drive to first piece while lowering elevator — run in parallel
+            Commands.parallel(
+                AutonomousCommands.followPath(drivetrain, "ScoreToFirstPiece"),
+                ElevatorCommands.goTo(elevator, ElevatorPosition.INTAKE)
+            ),
+
+            // 3. Grab the piece — sensor-gated with a timeout safety net
+            IntakeCommands.run(intake)
+                .until(intake::hasPiece)
+                .withTimeout(2.0),
+
+            // 4. Drive back and stage elevator simultaneously
+            Commands.parallel(
+                AutonomousCommands.followPath(drivetrain, "FirstPieceToScore"),
+                ElevatorCommands.goTo(elevator, ElevatorPosition.L2)
+            ),
+
+            // 5. Score
+            Commands.waitUntil(elevator::isAtTarget),
+            IntakeCommands.eject(intake).withTimeout(0.5),
+
+            // 6. Return elevator to stowed
+            ElevatorCommands.goTo(elevator, ElevatorPosition.STOWED)
+
+        ).unless(() -> !elevator.isHealthy());
+    }
+}

--- a/companion/level-5/ElevatorAuto/ElevatorCommands.java
+++ b/companion/level-5/ElevatorAuto/ElevatorCommands.java
@@ -1,0 +1,25 @@
+// Level 5 capstone — elevator + intake autonomous routine.
+// See: docs/source/guide-to-java-level-5.md — Capstone: Elevator + Intake Autonomous Routine
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem.ElevatorPosition;
+
+public final class ElevatorCommands {
+
+    private ElevatorCommands() {}
+
+    public static Command goTo(ElevatorSubsystem elevator, ElevatorPosition target) {
+        return Commands.sequence(
+            Commands.runOnce(() -> elevator.goTo(target), elevator),
+            Commands.waitUntil(elevator::isAtTarget)
+        ).withName("Elevator→" + target.name());
+    }
+
+    public static Command idle(ElevatorSubsystem elevator) {
+        return Commands.run(() -> {}, elevator).withName("ElevatorIdle");
+    }
+}

--- a/companion/level-6/VisionAssistedAuto/AutonomousRoutines.java
+++ b/companion/level-6/VisionAssistedAuto/AutonomousRoutines.java
@@ -1,0 +1,65 @@
+// Level 6 capstone — vision-assisted two-piece autonomous routine.
+// See: docs/source/guide-to-java-level-6.md — Capstone: Vision-Assisted Two-Piece Auto
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystems.DrivetrainSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem.ElevatorPosition;
+import frc.robot.subsystems.IntakeSubsystem;
+import frc.robot.subsystems.VisionSubsystem;
+
+public final class AutonomousRoutines {
+
+    private AutonomousRoutines() {}
+
+    /**
+     * Score preloaded piece, collect from source, score second piece.
+     * Applies vision corrections whenever tags are visible.
+     * Falls back to odometry automatically during dropouts.
+     */
+    public static Command scoreTwoPieceVision(
+        DrivetrainSubsystem drivetrain,
+        ElevatorSubsystem elevator,
+        IntakeSubsystem intake,
+        VisionSubsystem vision
+    ) {
+        return Commands.sequence(
+
+            Commands.runOnce(() -> {
+                if (vision.isDroppedOut()) {
+                    DriverStation.reportWarning(
+                        "Vision dropout at auto start — running odometry only", false);
+                }
+            }),
+
+            // Piece 1
+            Commands.parallel(
+                AutonomousCommands.followPath(drivetrain, "StartToReef1"),
+                ElevatorCommands.goTo(elevator, ElevatorPosition.L3)
+                    .unless(() -> !elevator.isHealthy())
+            ),
+            IntakeCommands.feed(intake).withTimeout(0.5),
+
+            // Travel to source
+            Commands.parallel(
+                AutonomousCommands.followPath(drivetrain, "Reef1ToSource"),
+                ElevatorCommands.goTo(elevator, ElevatorPosition.INTAKE)
+            ),
+            IntakeCommands.run(intake).until(intake::hasPiece).withTimeout(2.0),
+
+            // Piece 2
+            Commands.parallel(
+                AutonomousCommands.followPath(drivetrain, "SourceToReef2"),
+                ElevatorCommands.goTo(elevator, ElevatorPosition.L4)
+                    .unless(() -> !elevator.isHealthy())
+            ),
+            IntakeCommands.feed(intake).withTimeout(0.5),
+
+            ElevatorCommands.goTo(elevator, ElevatorPosition.STOWED)
+        );
+    }
+}

--- a/companion/level-6/VisionAssistedAuto/DriveToNearestScoringLocation.java
+++ b/companion/level-6/VisionAssistedAuto/DriveToNearestScoringLocation.java
@@ -1,0 +1,74 @@
+// Level 6 capstone — field-relative scoring command.
+// See: docs/source/guide-to-java-level-6.md — Part 5: Field-Relative Scoring Commands
+
+package frc.robot.commands;
+
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.DrivetrainSubsystem;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class DriveToNearestScoringLocation extends Command {
+
+    private static final List<Pose2d> REEF_BRANCHES = List.of(
+        new Pose2d(3.0, 4.1, Rotation2d.fromDegrees(180)),
+        new Pose2d(3.0, 3.5, Rotation2d.fromDegrees(180)),
+        new Pose2d(3.5, 3.2, Rotation2d.fromDegrees(150))
+        // Add all reef branch poses for your field layout
+    );
+
+    private final DrivetrainSubsystem drivetrain;
+    private Pose2d target;
+
+    private final ProfiledPIDController xController =
+        new ProfiledPIDController(5, 0, 0, new TrapezoidProfile.Constraints(3.0, 4.0));
+    private final ProfiledPIDController yController =
+        new ProfiledPIDController(5, 0, 0, new TrapezoidProfile.Constraints(3.0, 4.0));
+    private final ProfiledPIDController rotController =
+        new ProfiledPIDController(4, 0, 0, new TrapezoidProfile.Constraints(Math.PI, Math.PI * 2));
+
+    public DriveToNearestScoringLocation(DrivetrainSubsystem drivetrain) {
+        this.drivetrain = drivetrain;
+        rotController.enableContinuousInput(-Math.PI, Math.PI);
+        addRequirements(drivetrain);
+    }
+
+    @Override
+    public void initialize() {
+        Pose2d current = drivetrain.getPose();
+        target = REEF_BRANCHES.stream()
+            .min(Comparator.comparingDouble(p -> p.getTranslation()
+                .getDistance(current.getTranslation())))
+            .orElseThrow();
+
+        xController.reset(current.getX());
+        yController.reset(current.getY());
+        rotController.reset(current.getRotation().getRadians());
+    }
+
+    @Override
+    public void execute() {
+        Pose2d current = drivetrain.getPose();
+        drivetrain.driveFieldRelative(
+            xController.calculate(current.getX(), target.getX()),
+            yController.calculate(current.getY(), target.getY()),
+            rotController.calculate(current.getRotation().getRadians(),
+                                    target.getRotation().getRadians())
+        );
+    }
+
+    @Override
+    public boolean isFinished() {
+        return xController.atGoal() && yController.atGoal() && rotController.atGoal();
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        drivetrain.stop();
+    }
+}

--- a/companion/level-6/VisionAssistedAuto/VisionPoseUpdater.java
+++ b/companion/level-6/VisionAssistedAuto/VisionPoseUpdater.java
@@ -1,0 +1,32 @@
+// Level 6 capstone — vision-assisted two-piece autonomous routine.
+// See: docs/source/guide-to-java-level-6.md — Capstone: Vision-Assisted Two-Piece Auto
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class VisionPoseUpdater extends SubsystemBase {
+
+    private final DrivetrainSubsystem drivetrain;
+    private final VisionSubsystem vision;
+
+    public VisionPoseUpdater(DrivetrainSubsystem drivetrain, VisionSubsystem vision) {
+        this.drivetrain = drivetrain;
+        this.vision = vision;
+    }
+
+    @Override
+    public void periodic() {
+        // Provide current heading to MegaTag2 solver
+        vision.enableMegaTag2(drivetrain.getGyroAngle().getDegrees());
+
+        var estimate = vision.getLatestEstimate();
+        if (drivetrain.isValidEstimate(estimate)) {
+            drivetrain.addVisionMeasurement(
+                estimate.pose,
+                estimate.timestampSeconds,
+                drivetrain.getVisionStdDevs(estimate)
+            );
+        }
+    }
+}

--- a/companion/level-6/VisionAssistedAuto/VisionSubsystem.java
+++ b/companion/level-6/VisionAssistedAuto/VisionSubsystem.java
@@ -1,0 +1,46 @@
+// Level 6 capstone — vision-assisted two-piece autonomous routine.
+// See: docs/source/guide-to-java-level-6.md — Capstone: Vision-Assisted Two-Piece Auto
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.LimelightHelpers;
+import frc.robot.LimelightHelpers.PoseEstimate;
+
+public class VisionSubsystem extends SubsystemBase {
+
+    private static final String CAMERA = "limelight";
+    private static final double DROPOUT_THRESHOLD_SECONDS = 0.5;
+
+    private double lastValidTimestamp = 0;
+
+    // Enable MegaTag2 (IMU-assisted, multi-tag). Must be called before each measurement read.
+    public void enableMegaTag2(double robotYawDegrees) {
+        LimelightHelpers.SetRobotOrientation(CAMERA, robotYawDegrees, 0, 0, 0, 0, 0);
+    }
+
+    public PoseEstimate getLatestEstimate() {
+        return LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAMERA);
+    }
+
+    public boolean hasTarget() {
+        return LimelightHelpers.getTV(CAMERA);
+    }
+
+    @Override
+    public void periodic() {
+        var estimate = getLatestEstimate();
+        if (estimate != null && estimate.tagCount > 0) {
+            lastValidTimestamp = Timer.getFPGATimestamp();
+        }
+    }
+
+    public boolean isDroppedOut() {
+        return (Timer.getFPGATimestamp() - lastValidTimestamp) > DROPOUT_THRESHOLD_SECONDS;
+    }
+
+    public double getSecondsSinceLastUpdate() {
+        return Timer.getFPGATimestamp() - lastValidTimestamp;
+    }
+}

--- a/docs/source/guide-to-java-level-1.md
+++ b/docs/source/guide-to-java-level-1.md
@@ -628,6 +628,8 @@ team3603.printReport();
 2. Add algae tracking: processor scores 6 pts each, net scores 4 pts each. Add `recordAlgae(int processor, int net)`.
 3. Create two `MatchScorer` objects for two different teams, score them, then print which team won.
 
+> **Full project:** [`companion/level-1/MatchScorer`](https://github.com/CyberCoyotes/Programmers-Handbook/tree/main/companion/level-1/MatchScorer)
+
 ---
 
 ## **Learning Resources**

--- a/docs/source/guide-to-java-level-2.md
+++ b/docs/source/guide-to-java-level-2.md
@@ -597,6 +597,8 @@ public class IntakeCapstone extends LinearOpMode {
 2. Add a servo to the subsystem that opens a gate when `INTAKING` and closes it otherwise.
 3. Print a warning in telemetry if the motor power is non-zero but `getState()` returns `STOPPED` — that would indicate a bug.
 
+> **Full project:** [`companion/level-2/IntakeSubsystem`](https://github.com/CyberCoyotes/Programmers-Handbook/tree/main/companion/level-2/IntakeSubsystem)
+
 ---
 
 ## **Check Your Understanding**

--- a/docs/source/guide-to-java-level-3.md
+++ b/docs/source/guide-to-java-level-3.md
@@ -993,6 +993,8 @@ public class CoordinatedTeleOp extends LinearOpMode {
 2. Replace the simplified arm `update()` with real encoder-based position control using `DcMotorEx.setTargetPosition()`.
 3. Convert `hold()` from a manual driver input into an automatic sensor transition: when a beam-break sensor detects a game piece, `INTAKING` automatically transitions to `HOLDING`.
 
+> **Full project:** [`companion/level-3/CoordinatedRobot`](https://github.com/CyberCoyotes/Programmers-Handbook/tree/main/companion/level-3/CoordinatedRobot)
+
 ---
 
 ## **Check Your Understanding**

--- a/docs/source/guide-to-java-level-4.md
+++ b/docs/source/guide-to-java-level-4.md
@@ -514,7 +514,7 @@ You've learned subsystems, commands, requirements, default commands, and binding
 
 **The task:** A single-motor intake using a CTRE Talon FX (Kraken X60). A default command keeps it stopped when nothing is scheduled. A button-bound command runs it while the right trigger is held. The scheduler prevents conflicts automatically.
 
-> A deployable Gradle project for this capstone is planned for the companion repo (Phase 8).
+> **Full project:** [`companion/level-4/CommandIntake`](https://github.com/CyberCoyotes/Programmers-Handbook/tree/main/companion/level-4/CommandIntake)
 
 ### **`Constants.java`**
 

--- a/docs/source/guide-to-java-level-5.md
+++ b/docs/source/guide-to-java-level-5.md
@@ -1391,6 +1391,8 @@ public final class AutonomousRoutines {
 2. Replace `.withTimeout(2.0)` on the intake command with a sensor trigger — schedule `ElevatorCommands.goTo(STOWED)` automatically the moment `intake.hasPiece()` becomes true.
 3. Add a `SendableChooser` in `RobotContainer` that lets you pick between scoring L4+L2 (this routine) and a simpler L1-only routine for qualification matches where you just need to leave the zone.
 
+> **Full project:** [`companion/level-5/ElevatorAuto`](https://github.com/CyberCoyotes/Programmers-Handbook/tree/main/companion/level-5/ElevatorAuto)
+
 ---
 
 ## **Common Patterns Summary**

--- a/docs/source/guide-to-java-level-6.md
+++ b/docs/source/guide-to-java-level-6.md
@@ -585,6 +585,8 @@ public final class AutonomousRoutines {
 - Tune the stdDevs by logging `drivetrain.getPose()` vs. raw vision pose across several test runs and computing average error at different distances
 - Add a `ShuffleboardTab` that shows: last vision update age, tag count, current pose, estimated error
 
+> **Full project:** [`companion/level-6/VisionAssistedAuto`](https://github.com/CyberCoyotes/Programmers-Handbook/tree/main/companion/level-6/VisionAssistedAuto)
+
 ---
 
 ## **Reference Card**


### PR DESCRIPTION
## Summary

- Creates `companion/` directory with 16 Java source files — one project per level capstone, organized as `companion/level-N/ProjectName/*.java`
- Adds `.github/workflows/companion-check.yml` — verifies all expected companion files exist on every push and PR
- Adds `companion/README.md` documenting the directory structure and link convention
- Adds a `Full project:` blockquote link at the end of each level's capstone section (levels 1–6), pointing to the GitHub tree URL for that companion folder
- Replaces the Level 4 "planned for Phase 8" placeholder with the live companion link

## Companion projects

| Level | Project | Files |
| :---- | :---- | :---- |
| 1 | `MatchScorer` | `MatchScorer.java` |
| 2 | `IntakeSubsystem` | `IntakeSubsystem.java`, `IntakeCapstone.java` |
| 3 | `CoordinatedRobot` | `IntakeSubsystem.java`, `ArmSubsystem.java`, `CoordinatedTeleOp.java` |
| 4 | `CommandIntake` | `Constants.java`, `IntakeSubsystem.java`, `IntakeCommands.java`, `RobotContainer.java` |
| 5 | `ElevatorAuto` | `ElevatorCommands.java`, `AutonomousRoutines.java` |
| 6 | `VisionAssistedAuto` | `VisionSubsystem.java`, `VisionPoseUpdater.java`, `DriveToNearestScoringLocation.java`, `AutonomousRoutines.java` |

## Test plan

- [ ] `mkdocs build --strict` passes (verified locally)
- [ ] Companion-check CI passes — all 16 expected files present
- [ ] Link-check CI passes — all `Full project:` links resolve to valid GitHub tree URLs
- [ ] `Full project:` links render correctly in the handbook

https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt)_