### PR TITLE
Convert Level 1/2 diagrams to Mermaid and align progression with higher levels

### DIFF
--- a/docs/source/guide-to-java-level-1.md
+++ b/docs/source/guide-to-java-level-1.md
@@ -10,16 +10,18 @@ Any FIRST student — FTC or FRC — who needs to learn Java basics. No robot co
 
 ```mermaid
 flowchart TD
-
     A["LEVEL 1: Java Foundations<br/>(You are here)"]
-
-    B["LEVEL 2<br/>Java for FTC<br/>(Middle School)"]
-    C["LEVEL 3<br/>Java for FTC<br/>(Middle School)"]
-    D["LEVEL 4<br/>FRC Basics<br/>(High School)"]
+    B["LEVEL 2: Java for FTC<br/>Robot Programming Basics"]
+    C["LEVEL 3: Advanced FTC Patterns<br/>State Machines & Subsystems"]
+    D["LEVEL 4: FRC Basics<br/>FTC → Command-Based Transition"]
+    E["LEVEL 5: Advanced FRC<br/>Commands, Triggers, and Auto"]
+    F["LEVEL 6: Vision-Assisted Auto<br/>Localization & Sensor Fusion"]
 
     A --> B
     B --> C
-    A --> D
+    C --> D
+    D --> E
+    E --> F
 ```
 
 ## **How to Use This Guide**

--- a/docs/source/guide-to-java-level-2.md
+++ b/docs/source/guide-to-java-level-2.md
@@ -8,23 +8,16 @@ Middle school FTC students who have completed **Level 1: Java Foundations**. Thi
 
 ## **Your Learning Path**
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                 LEVEL 1: Java Foundations                   │
-│            (Recommended if new to Java)                     │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                   LEVEL 2: Java for FTC                     │
-│                      (You are here)                         │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│              LEVEL 3: Advanced FTC Patterns                 │
-│   State machines • Subsystem classes • Competition code     │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    A["LEVEL 1: Java Foundations<br/>(Recommended if new to Java)"]
+    B["LEVEL 2: Java for FTC<br/>(You are here)"]
+    C["LEVEL 3: Advanced FTC Patterns<br/>State Machines • Subsystems • Competition Code"]
+    D["LEVEL 4: FRC Basics<br/>FTC → Command-Based Transition"]
+
+    A --> B
+    B --> C
+    C --> D
 ```
 
 **Already know Java?** Skip to Part 2 and start learning FTC-specific patterns.
@@ -35,16 +28,19 @@ Middle school FTC students who have completed **Level 1: Java Foundations**. Thi
 
 ### **How FTC Code is Organized**
 
-```
-TeamCode/
-├── java/
-│   └── org/firstinspires/ftc/teamcode/
-│       ├── TeleOp/           ← Driver-controlled programs
-│       │   └── MainTeleOp.java
-│       ├── Autonomous/       ← Self-driving programs
-│       │   └── RedLeft.java
-│       └── Subsystems/       ← Reusable mechanism code (optional)
-│           └── Intake.java
+```mermaid
+flowchart TD
+    A["TeamCode/java/org/firstinspires/ftc/teamcode"]
+    B["TeleOp/<br/>Driver-controlled programs"]
+    C["Autonomous/<br/>Self-driving programs"]
+    D["Subsystems/<br/>Reusable mechanism code"]
+    E["MainTeleOp.java"]
+    F["RedLeft.java"]
+    G["Intake.java"]
+
+    A --> B --> E
+    A --> C --> F
+    A --> D --> G
 ```
 
 ### **The OpMode: Your Robot's Brain**


### PR DESCRIPTION
### Motivation
- Make Level 1 and Level 2 visuals consistent with the Mermaid diagrams used in Level 3+ so the handbook has a unified diagram style. 
- Clarify the learning-path progression across FTC and FRC by showing Levels 1–6 in a single, coherent flow. 
- Replace fragile ASCII/tree art with renderable Mermaid flowcharts so diagrams remain maintainable and portable.

### Description
- Replaced the Level 1 learning-path block in `docs/source/guide-to-java-level-1.md` with a Mermaid `flowchart` that shows Levels 1 through 6 and updates the progression arrows. 
- Replaced the Level 2 ASCII learning-path with a Mermaid `flowchart` and converted the Level 2 project-structure tree into a Mermaid flowchart in `docs/source/guide-to-java-level-2.md`. 
- Adjusted wording in the Level 1/2 diagrams to match terminology used in higher-level guides (e.g., “State Machines & Subsystems”, “FTC → Command-Based Transition”). 
- Changes are limited to `docs/source/guide-to-java-level-1.md` and `docs/source/guide-to-java-level-2.md`.

### Testing
- Reviewed the unified diff of the two modified files using `git diff -- docs/source/guide-to-java-level-1.md docs/source/guide-to-java-level-2.md` and inspected the changed sections. 
- Printed the top of each updated file with `nl -ba` to confirm the Mermaid fences and flowchart blocks render as expected in the source. 
- Created the PR metadata via the repository PR helper and verified the PR body describes the change; all automated checks performed during this workflow completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0091b3d904832aa233af680fabb3cd)