### PR TITLE
Phase 9: Coach Notes Sweep

### DIFF
--- a/docs/source/guide-to-java-level-1.md
+++ b/docs/source/guide-to-java-level-1.md
@@ -530,6 +530,10 @@ double average = (double) sum / numbers.length;
 System.out.println("Average: " + average);  // Average: 5.0
 ```
 
+!!! warning "Coach: common pitfall"
+    <!-- category: common student misconception -->
+    **Off-by-one errors are the most common array bug.** Students reliably write `i <= arr.length` in the loop condition — `<=` causes an `ArrayIndexOutOfBoundsException` on the last pass because valid indices only go up to `arr.length - 1`. Rather than correcting this before it happens, let them write an array loop and hit the exception. Then ask: "what does the stack trace tell you about which line threw it?" Reading an exception message and connecting it back to an index is more valuable than never seeing one.
+
 ---
 
 ## **Capstone: `MatchScorer`**

--- a/docs/source/guide-to-java-level-2.md
+++ b/docs/source/guide-to-java-level-2.md
@@ -406,6 +406,10 @@ public class BetterAuto extends LinearOpMode {
 }
 ```
 
+!!! note "Coach"
+    <!-- category: let them fail here -->
+    **Let them use time-based auto and watch it fail at a scrimmage.** At a practice event, battery voltage drops through the match, the field surface varies, and the robot ends up a tile off. Resist the urge to warn them beforehand. After the mismatch, ask: "what measurement would have helped?" That question gets students to encoders and state-based auto on their own. A lesson learned by watching the robot go the wrong way is remembered all season.
+
 ---
 
 ## **Part 6: Organizing Your Code**
@@ -471,6 +475,10 @@ public class OrganizedTeleOp extends LinearOpMode {
     }
 }
 ```
+
+!!! note "Coach"
+    <!-- category: real-robot demo opportunity -->
+    **Open two files side by side: the 200-line monolith and the refactored version.** Ask: "where do you look to change the intake speed?" In the monolith they have to search. In the subsystem class they go straight to `IntakeSubsystem.java`. That 30-second demo makes the case for organization better than any explanation — students who see it usually restructure their own code voluntarily.
 
 ---
 

--- a/docs/source/guide-to-java-level-3.md
+++ b/docs/source/guide-to-java-level-3.md
@@ -568,6 +568,10 @@ Look how clean that is\! Each subsystem manages itself. The OpMode just handles 
     <!-- category: ecosystem convergence -->
     **`update()` calls become `periodic()` in WPILib.** In current FTC, you call `intake.update()` and `arm.update()` explicitly at the end of each loop iteration. In FRC — and in the converging FTC ecosystem — one call to `CommandScheduler.getInstance().run()` inside `robotPeriodic()` calls `periodic()` on every registered subsystem and advances every scheduled command. The mental model shifts from "I drive every subsystem" to "I declare what I want; the scheduler drives it." The subsystem code itself barely changes.
 
+!!! note "Coach"
+    <!-- category: common student misconception -->
+    **Students put logic in the OpMode that belongs in the subsystem.** The tell is a method like `setPower(double)` on the subsystem paired with a big `if/else` block in the OpMode that decides what value to pass. Flip it: the subsystem exposes `intake()`, `hold()`, `stop()` — not `setPower()`. The OpMode sets *desired state*; the subsystem computes hardware output. When this pattern clicks, the OpMode shrinks to a handful of lines and the subsystem becomes independently readable and testable.
+
 ---
 
 ## **Part 3: State-Based Autonomous**
@@ -736,6 +740,10 @@ public class StateMachineAuto extends LinearOpMode {
 | No parallel actions | Multiple things at once |
 | Hard to debug | Clear current state |
 
+!!! note "Coach"
+    <!-- category: let them fail here -->
+    **Let them use sleep-based auto for one competition.** Time-based auto looks correct but the robot ends up in the wrong place because battery voltage and field conditions vary match to match. Resist warning them in advance. After the mismatch, ask: "what would you need to measure to make this reliable?" That question leads students to encoders, state machines, and sensor-gated transitions on their own — a lesson learned by watching the robot go the wrong way is remembered all season.
+
 ---
 
 ## **Part 4: Coordinating Multiple Subsystems**
@@ -836,6 +844,10 @@ private void setState(State newState) {
 | Rapidly switching states | No debouncing or condition too sensitive | Add stability check |
 | Wrong state after button press | Multiple states responding to same input | Check state guards |
 | Subsystem does nothing | Forgot to call `update()` | Add update() to main loop |
+
+!!! note "Coach"
+    <!-- category: real-robot demo opportunity -->
+    **Demo the "stuck state" bug live.** Write a state machine where the exit condition is `hasSample()` but the sensor cable is unplugged — the intake runs forever. Ask: "what does telemetry show? What does that tell you?" This exercise teaches both the debugging process (telemetry first, then hardware check) and why every long-running state should have a timeout fallback. Students remember it because the robot is sitting right there, misbehaving, while they figure it out.
 
 ---
 


### PR DESCRIPTION
## Summary

Fills coach note coverage gaps so every major Part across all six levels has at least one coach callout.

**6 notes added across levels 1–3** (levels 4–6 were already well-covered):

| Level | Part | Category | Note |
| :---- | :---- | :---- | :---- |
| 1 | Part 5: Arrays | common student misconception | Off-by-one `ArrayIndexOutOfBoundsException` — let them hit it and read the stack trace |
| 2 | Part 5: Basic Autonomous | let them fail here | Time-based auto fails at scrimmage; battery voltage and field variation motivate encoders |
| 2 | Part 6: Organizing Your Code | real-robot demo opportunity | Monolith vs. subsystem side-by-side: "where do you look to change the intake speed?" |
| 3 | Part 2: Organized Subsystems | common student misconception | `setPower(double)` on subsystem + big if/else in OpMode — should be intent methods only |
| 3 | Part 3: State-Based Autonomous | let them fail here | Sleep-based auto at competition; mismatch motivates state machines |
| 3 | Part 5: Debugging State Machines | real-robot demo opportunity | Stuck-state drill: unplug sensor cable, watch intake run forever, diagnose via telemetry |

**Final counts:** L1=5, L2=7, L3=6, L4=4, L5=5, L6=5 — all meet the ≥3 acceptance criterion with ≥1 note per major Part.

## Test plan

- [ ] All 6 new admonitions render correctly (note / warning style)
- [ ] Each note has a `<!-- category: ... -->` tag in source
- [ ] No existing notes were altered

https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt)_