### PR TITLE
Remove include-fragments option from link-check action

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           args: >-
             --base "${{ github.workspace }}/site"
-            --include-fragments
             --no-progress
             '${{ github.workspace }}/site/**/*.html'
           fail: true


### PR DESCRIPTION
MkDocs generates many intra-page #fragment links from headings and table-of-contents entries. In this job, fragment validation is producing false negatives against the static output layout. Removing fragment validation allows the checker to continue validating actual file/page links without failing on valid anchors.