### PR TITLE
Phase 10: Final Polish

### DIFF
--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -1,0 +1,219 @@
+# Glossary
+
+Terms used consistently throughout this handbook. When a word has multiple industry spellings or synonyms, the form listed here is the one used in all code examples and prose.
+
+---
+
+## A
+
+**admonition**
+A styled callout block in the handbook (e.g., `!!! note "Coach"` or `??? info`). Used for coach notes, Current FTC sidebars, and warnings.
+
+**AprilTag**
+A fiducial marker used on FRC and FTC fields. Cameras detect them to estimate the robot's 3D position relative to a known tag location.
+
+**autonomous** (also: *auto*)
+The first 15 seconds of an FRC match (or 30 seconds in FTC) during which the robot operates without driver input.
+
+---
+
+## C
+
+**CANcoder**
+A CTRE magnetic encoder that communicates over the CAN bus. Used to measure absolute swerve module angle in Phoenix 6 swerve drives.
+
+**CAN bus** (Controller Area Network)
+The wired network that connects the roboRIO to CTRE and REV motor controllers, the Pigeon 2 IMU, and other devices. Device IDs must be unique.
+
+**Choreo**
+A trajectory authoring app for FRC swerve drives. Exports `.traj` files that ChoreoLib reads at runtime to follow the path.
+
+**command** (FRC)
+A unit of robot behavior in WPILib's command-based framework. Commands declare which subsystems they require and implement `initialize()`, `execute()`, `isFinished()`, and `end()`.
+
+**`CommandScheduler`**
+The WPILib singleton that runs every scheduled command once per 20 ms loop and resolves requirement conflicts between commands.
+
+**CTRE** (Cross The Road Electronics)
+The vendor that makes Talon FX motor controllers, CANcoders, and the Pigeon 2 IMU. Their API is called Phoenix 6 in current FRC.
+
+---
+
+## D
+
+**dead-wheel odometry**
+Position tracking using unpowered wheels (contact wheels or omni wheels) connected to encoders, not affected by motor slip.
+
+**default command**
+A command that runs on a subsystem whenever no other command requiring that subsystem is scheduled. Set with `subsystem.setDefaultCommand()`.
+
+---
+
+## E
+
+**encoder**
+A sensor that measures motor or wheel rotation. Relative encoders reset on power-up; absolute encoders (e.g., CANcoder) remember position across power cycles.
+
+---
+
+## F
+
+**feedforward**
+A control term calculated from a model of the mechanism (gravity, friction, velocity) rather than from sensor error. Added to PID output to reduce steady-state error.
+
+**field-relative**
+Describes drive commands or poses defined in the fixed coordinate frame of the field, not the robot. "Forward" always means toward the opposing alliance wall.
+
+**FRC** (FIRST Robotics Competition)
+The senior-level FIRST program. Uses WPILib, Java or C++, and 120-pound robots competing in a 54×27 ft field.
+
+**FTC** (FIRST Tech Challenge)
+The middle-school/high-school FIRST program. Uses the FTC SDK, Java, and 18×18 in robots competing in a 12×12 ft field.
+
+---
+
+## G
+
+**gamepad** (also: *controller*)
+The driver input device. FTC: any Android-compatible USB gamepad via the Driver Hub. FRC: Xbox-compatible controller via a USB port on the Driver Station laptop.
+
+---
+
+## H
+
+**hardwareMap**
+The FTC SDK object used to retrieve hardware devices by name. Example: `hardwareMap.get(DcMotor.class, "intake")`. The name must match the robot configuration exactly.
+
+---
+
+## I
+
+**IMU** (Inertial Measurement Unit)
+A sensor that measures rotation rate and acceleration. The Pigeon 2 (FRC) and built-in REV Control Hub IMU (FTC) provide heading data used by odometry and field-relative drive.
+
+---
+
+## K
+
+**Kalman filter**
+A statistical algorithm that blends multiple noisy measurements (e.g., wheel odometry + vision) weighted by their expected noise. `SwerveDrivePoseEstimator` uses one internally.
+
+**Kraken X60**
+A brushless motor made by WestCoast Products / Vex. Paired with a Talon FX motor controller. The primary drive and mechanism motor in current CTRE-stack FRC robots.
+
+---
+
+## L
+
+**latency compensation**
+Adjusting a vision pose measurement for the time it took the camera to capture and process the frame, so the correction is applied to the robot's past position rather than its current position.
+
+**Limelight**
+A smart camera system for FRC/FTC. The Limelight 4 (with Hailo coprocessor) performs AprilTag 3D pose estimation onboard and publishes results via NetworkTables.
+
+**`LinearOpMode`**
+The FTC SDK base class for programs that run top-to-bottom in a single thread. Most FTC programs use this. Contrast with the iterative `OpMode`.
+
+---
+
+## M
+
+**mechanism** (avoid in handbook prose)
+Generic term for a robot mechanism. The handbook prefers *subsystem* to match WPILib naming.
+
+**MegaTag2**
+Limelight's multi-tag, IMU-assisted pose solving mode. Produces a tighter XY estimate than single-tag solving. Do not trust its rotation output — use the gyro directly.
+
+---
+
+## O
+
+**odometry**
+Estimating the robot's field position by integrating wheel encoder and gyro readings over time. Accumulates error; corrected by vision in Level 6.
+
+**OpMode** (FTC)
+A top-level FTC program, annotated with `@TeleOp` or `@Autonomous`. Appears on the Driver Hub menu. Equivalent concept to an FRC `Robot` class.
+
+---
+
+## P
+
+**`periodic()`**
+The WPILib method called every 20 ms on every registered subsystem. Equivalent to the `update()` pattern used in FTC subsystem classes in this handbook.
+
+**Phoenix 6**
+CTRE's current Java API for Talon FX, CANcoder, and Pigeon 2. Uses control-request objects (`DutyCycleOut`, `PositionVoltage`) passed to `motor.setControl()`.
+
+**Pigeon 2**
+A CTRE IMU that provides heading and rotation rate via CAN. Used as the gyro source for swerve odometry and field-relative drive.
+
+**pose** (also: *Pose2d*)
+A robot's position and heading on the field, represented as `(x meters, y meters, rotation)`. The WPILib class is `Pose2d`.
+
+**`ProfiledPIDController`**
+A WPILib PID controller with a built-in `TrapezoidProfile` that limits commanded velocity and acceleration, preventing mechanical shock on position-controlled mechanisms.
+
+---
+
+## R
+
+**requirement**
+The subsystem a command declares it needs exclusive access to. The `CommandScheduler` prevents two commands from requiring the same subsystem simultaneously. Set via `addRequirements()` or the subsystem argument to factory methods.
+
+**`RobotContainer`**
+The WPILib class where subsystems are instantiated and button bindings are configured. Created once by the framework at startup.
+
+---
+
+## S
+
+**standard deviation** (in pose estimation)
+A measure of sensor noise passed to `addVisionMeasurement()`. Lower values mean "trust this source more." Never trust vision rotation — pass a large value (e.g., 9999) for that axis.
+
+**state machine**
+A programming pattern where a system is always in exactly one state (e.g., `IDLE`, `INTAKING`, `HOLDING`), and transitions between states are triggered by conditions or events.
+
+**subsystem**
+A class that owns all hardware for one robot mechanism and exposes intent-based methods (`intake()`, `stop()`). In FRC, extends `SubsystemBase`. In FTC (this handbook), a plain class with an `update()` method.
+
+**swerve drive**
+A drivetrain where each wheel module can rotate independently, allowing the robot to translate in any direction while facing any heading.
+
+**`SwerveDrivePoseEstimator`**
+A WPILib class that fuses wheel odometry with periodic vision corrections using a Kalman filter. Drop-in replacement for `SwerveDriveOdometry` when vision is available.
+
+---
+
+## T
+
+**Talon FX**
+A CTRE brushless motor controller with a built-in encoder, compatible with Kraken X60 and Falcon 500 motors. Controlled via Phoenix 6 in current FRC.
+
+**teleop**
+The 2:15 driver-controlled period of an FRC match (or 1:30 in FTC) following autonomous.
+
+**telemetry**
+Data displayed on the Driver Hub screen (FTC) or SmartDashboard/Shuffleboard (FRC) during a match. Used for debugging and driver feedback.
+
+**`TrapezoidProfile`**
+A WPILib motion profile that limits acceleration and velocity to produce a smooth trapezoidal velocity curve, preventing mechanical shock on position-controlled mechanisms.
+
+**`Trigger`**
+A WPILib class representing a boolean condition (button press, sensor reading, etc.) that can schedule commands when it becomes active or inactive. Composed with `.whileTrue()`, `.onTrue()`, `.toggleOnTrue()`, etc.
+
+---
+
+## V
+
+**vendor dependency** (also: *vendordep*)
+A JSON file that tells the WPILib Gradle build where to download a third-party library (CTRE Phoenix 6, ChoreoLib, etc.). Placed in `vendordeps/` in the project root.
+
+**vision dropout**
+A period when the camera cannot detect any AprilTags. The pose estimator falls back to wheel odometry automatically; vision corrections resume when tags reappear.
+
+---
+
+## W
+
+**WPILib**
+The official Java/C++ library for FRC robot programming. Provides the command-based framework, hardware abstractions, mathematics utilities, and simulation tools used in Levels 4–6.

--- a/docs/source/guide-to-java-level-1.md
+++ b/docs/source/guide-to-java-level-1.md
@@ -4,7 +4,8 @@
 
 Any FIRST student — FTC or FRC — who needs to learn Java basics. No robot code here, just the fundamentals you'll need before touching any robot programming.  
 **Prerequisites:** None. Complete beginner friendly.  
-**Time to Complete:** 2-4 weeks with daily practice (30-60 min/day)
+**Time to Complete:** 2-4 weeks with daily practice (30-60 min/day)  
+**Reference:** [Glossary](glossary.md)
 
 ## **Your Learning Path**
 

--- a/docs/source/guide-to-java-level-2.md
+++ b/docs/source/guide-to-java-level-2.md
@@ -4,7 +4,8 @@
 
 Middle school FTC students who have completed **Level 1: Java Foundations**. This guide bridges pure Java knowledge into FTC robot programming.  
 **Prerequisites:** Java basics (Level 1 or equivalent — a class, self-taught, or prior experience)  
-**Time to Complete:** 2-3 weeks alongside robot build
+**Time to Complete:** 2-3 weeks alongside robot build  
+**Reference:** [Glossary](glossary.md)
 
 ## **Your Learning Path**
 

--- a/docs/source/guide-to-java-level-3.md
+++ b/docs/source/guide-to-java-level-3.md
@@ -6,7 +6,8 @@ FTC students who have the basics down and want to write cleaner, more reliable c
 
 **Prerequisites:** Level 2: Java for FTC (or equivalent experience)
 
-**Time to Complete:** 2-3 weeks alongside competition prep
+**Time to Complete:** 2-3 weeks alongside competition prep  
+**Reference:** [Glossary](glossary.md)
 
 ---
 
@@ -217,7 +218,7 @@ public class StateMachineTeleOp extends LinearOpMode {
 
 Visualize your state machine before coding:
 
-```
+```text
                     ┌─────────────────────────────┐
                     │                             │
                     ▼                             │
@@ -274,7 +275,7 @@ public class MessyTeleOp extends LinearOpMode {
 
 Break your robot into logical pieces:
 
-```
+```text
 Robot
 ├── Drivetrain (4 motors)
 ├── Intake (1 motor, 1 sensor)

--- a/docs/source/guide-to-java-level-4.md
+++ b/docs/source/guide-to-java-level-4.md
@@ -4,7 +4,8 @@
 
 High school FRC students transitioning from FTC, or students with Java basics who are new to FRC. This guide bridges what you already know into FRC's Command-Based framework.  
 **Prerequisites:** Java basics (Level 1\) and ideally FTC experience (Level 2/3)  
-**Time to Complete:** 1-2 weeks before build season
+**Time to Complete:** 1-2 weeks before build season  
+**Reference:** [Glossary](glossary.md)
 
 ## **Your Learning Path**
 
@@ -75,7 +76,7 @@ This feels weird at first, but it's powerful:
 
 ### **FTC Structure (What You Know)**
 
-```
+```text
 TeamCode/
 └── org/firstinspires/ftc/teamcode/
     ├── TeleOp/
@@ -85,7 +86,7 @@ TeamCode/
 
 ### **FRC Structure (What's New)**
 
-```
+```text
 src/main/java/frc/robot/
 ├── Robot.java              ← Framework entry point (don't touch much)
 ├── RobotContainer.java     ← YOUR MAIN FILE: create subsystems, bind buttons

--- a/docs/source/guide-to-java-level-5.md
+++ b/docs/source/guide-to-java-level-5.md
@@ -6,7 +6,8 @@ FRC students who understand the basics of Command-Based and want to level up. Th
 
 **Prerequisites:** Level 4: FRC Basics (comfortable with subsystems, basic commands, button bindings)
 
-**Time to Complete:** Ongoing reference throughout the season
+**Time to Complete:** Ongoing reference throughout the season  
+**Reference:** [Glossary](glossary.md)
 
 ## **Your Learning Path**
 
@@ -652,7 +653,7 @@ public class Arm extends SubsystemBase {
 
 Drawing a state diagram helps design your state machine:
 
-```
+```text
                     ┌───────────────────────┐
                     │                       │
                     ▼                       │
@@ -1036,7 +1037,7 @@ Choreo is a desktop application for designing robot paths. It exports a `.traj` 
 
 Choreo exports to `deploy/choreo/<name>.traj`. This directory is deployed to the roboRIO by WPILib's Gradle build.
 
-```
+```text
 src/
 └── main/
     └── deploy/
@@ -1129,7 +1130,7 @@ public void resetOdometry(Pose2d pose) {
 
 ### **The Feedback Loop**
 
-```
+```text
 Trajectory (desired pose at time t)
          │
          ▼

--- a/docs/source/guide-to-java-level-6.md
+++ b/docs/source/guide-to-java-level-6.md
@@ -6,7 +6,8 @@ FRC students who have completed Level 5 and are ready to add 3D vision to their 
 
 **Prerequisites:** Level 5: Advanced FRC Patterns (comfortable with path following, motion profiling, command compositions, fault handling)
 
-**Time to Complete:** 3–5 weeks; best done alongside a working swerve drivetrain
+**Time to Complete:** 3–5 weeks; best done alongside a working swerve drivetrain  
+**Reference:** [Glossary](glossary.md)
 
 ## **Your Learning Path**
 
@@ -220,7 +221,7 @@ A Limelight measurement takes time to arrive. By the time the robot reads `botpo
 
 ### **Where the Latency Comes From**
 
-```
+```text
 Camera captures frame
     │
     ▼  (pipeline latency: tag detection + solve)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
     - Level 4: guide-to-java-level-4.md
     - Level 5: guide-to-java-level-5.md
     - Level 6: guide-to-java-level-6.md
+  - Glossary: glossary.md
 
 plugins:
   - search


### PR DESCRIPTION
## Summary

Cross-cutting cleanup that makes the whole handbook read as one coherent work.

### Glossary (`docs/source/glossary.md`) — new file
40+ terms covering the full L1–L6 vocabulary, alphabetically organized:
- Core concepts: subsystem, command, state machine, requirement, default command
- Hardware: Talon FX, Kraken X60, CANcoder, Pigeon 2, Limelight, hardwareMap
- Control theory: feedforward, Kalman filter, TrapezoidProfile, ProfiledPIDController, standard deviation
- Vision: AprilTag, MegaTag2, latency compensation, vision dropout, pose, SwerveDrivePoseEstimator
- FTC/FRC: LinearOpMode, OpMode, WPILib, Phoenix 6, Choreo, vendor dependency

Added to `mkdocs.yml` nav as a top-level **Glossary** entry.

### Glossary link in every level
`**Reference:** [Glossary](glossary.md)` added to the "Who Is This For?" block in all six levels so readers can always find definitions.

### Code fence language tags
8 bare opening fences fixed (tagged as `text`):
- Level 3: state-machine ASCII diagram, robot file-tree diagram
- Level 4: FTC project structure tree, FRC project structure tree
- Level 5: state-machine ASCII diagram, Choreo deploy tree, odometry feedback-loop diagram
- Level 6: latency-source ASCII diagram

### Build verification
`mkdocs build --strict` — 0 errors, 0 warnings.

## Test plan

- [ ] Glossary page renders and all anchor links resolve
- [ ] All six levels show the Glossary link in their header block
- [ ] `text` fenced blocks render as plain monospace (no syntax highlighting errors)
- [ ] `mkdocs build --strict` passes in CI
- [ ] Link-check CI passes (glossary internal links are fragments, not external)

https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcSYZBaZqnEHjHzrhdeVt)_